### PR TITLE
apply Thomas' patch from coding-standards...

### DIFF
--- a/config/phpcs/Rebuy/ruleset.xml
+++ b/config/phpcs/Rebuy/ruleset.xml
@@ -15,6 +15,7 @@
     <rule ref="Squiz.Functions.GlobalFunction"/>
     <rule ref="Zend.Debug.CodeAnalyzer"/>
     <rule ref="Zend.Files.ClosingTag"/>
+    <rule ref="PSR2.Files.EndFileNewline"/>
 
     <rule ref="Rebuy.CodingConventions.ArithmeticTokensSurroundedBySpaces"/>
     <rule ref="Rebuy.CodingConventions.AssignmentTokensSurroundedBySpaces"/>


### PR DESCRIPTION
...concerning newLineAtEndOfLine ([patch from 2013-10-09](https://github.com/rebuy-de/coding-standards/commit/73adf308999fe8ea276d1f54994f0db6457d406c)) to the php-tools repo

@omares @thomaskneisel 
