### PR TITLE
php code sniffs: allow accessing underscored property names

### DIFF
--- a/config/phpcs/Rebuy/Sniffs/CodingConventions/ValidVariableNameSniff.php
+++ b/config/phpcs/Rebuy/Sniffs/CodingConventions/ValidVariableNameSniff.php
@@ -68,9 +68,12 @@ class Rebuy_Sniffs_CodingConventions_ValidVariableNameSniff extends PHP_CodeSnif
                     }
 
                     if (PHP_CodeSniffer::isCamelCaps($objVarName, false, true, false) === false) {
-                        $error = 'Variable "%s" is not in valid camel caps format';
-                        $data  = array($originalVarName);
-                        $phpcsFile->addError($error, $var, 'NotCamelCaps', $data);
+                        // allow accessing properties that are named like MySQL columns 
+                        if (!preg_match('/^[a-z][a-z0-9_]*$/', $objVarName)) {
+                                $error = 'Variable "%s" is not in valid camel caps format';
+                                $data = array($originalVarName);
+                                $phpcsFile->addError($error, $var, 'NotCamelCaps', $data);
+			}
                     }
                 }//end if
             }//end if


### PR DESCRIPTION
@rebuy-de/it-development 

We _do_ use underscored property names all the time when working with Zend `TableRow` instances.
This will not change anytime soon.

I propose to remove the code sniff for underscores _when somebody is accessing_ properties.

That is: 
- `$x = $bla->bl_ub;` will be allowed
- `private $bl_ub` will still be forbidden

edit: clarification
